### PR TITLE
feat(measurements): add project + lot measurement units and unified p…

### DIFF
--- a/app/controllers/api/v1/lots_controller.rb
+++ b/app/controllers/api/v1/lots_controller.rb
@@ -41,6 +41,7 @@ class Api::V1::LotsController < ApplicationController
         project_name: lot.project&.name || "N/A",
         name: lot.name,
         reserved_by: reservation_text,
+        measurement_unit: lot.measurement_unit || lot.project.measurement_unit,
         price: lot.price,
         length: lot.length,
         width: lot.width,

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::ProjectsController < ApplicationController
 
   # Define fields allowed for search & sort
   SEARCHABLE_FIELDS = %w[name description address].freeze
-  SORTABLE_FIELDS   = %w[name created_at project_type price_per_square_vara].freeze
+  SORTABLE_FIELDS   = %w[name created_at project_type price_per_square_unit].freeze
 
   # GET /api/v1/projects
   def index
@@ -36,7 +36,7 @@ class Api::V1::ProjectsController < ApplicationController
         name: project.name,
         description: project.description,
         project_type: project.project_type,
-        price_per_square_vara: project.price_per_square_vara,
+  price_per_square_unit: project.price_per_square_unit,
         address: project.address,
         total_lots: project.lot_count,
         available: project.lots.where(status: 'available').count,
@@ -94,6 +94,6 @@ class Api::V1::ProjectsController < ApplicationController
   end
 
   def project_params
-    params.require(:project).permit(:name, :description, :project_type, :address, :lot_count, :price_per_square_vara, :interest_rate, :commission_rate)
+    params.require(:project).permit(:name, :description, :project_type, :address, :lot_count, :price_per_square_unit, :measurement_unit, :interest_rate, :commission_rate)
   end
 end

--- a/app/models/concerns/measurement_units.rb
+++ b/app/models/concerns/measurement_units.rb
@@ -1,0 +1,17 @@
+module MeasurementUnits
+  M2_TO_FT2 = 10.7639
+  M2_TO_VARA2 = 1.431
+
+  def self.convert_area(area_m2, unit)
+    case unit
+    when nil, 'm2'
+      area_m2
+    when 'ft2'
+      area_m2 * M2_TO_FT2
+    when 'vara2'
+      area_m2 * M2_TO_VARA2
+    else
+      area_m2
+    end
+  end
+end

--- a/app/models/lot.rb
+++ b/app/models/lot.rb
@@ -19,16 +19,7 @@ class Lot < ApplicationRecord
   end
 
   def area_in_project_unit
-    case measurement_unit || project&.measurement_unit
-    when 'm2'
-      area_m2
-    when 'ft2'
-      area_m2 * 10.7639
-    when 'vara2'
-      area_m2 * 1.431
-    else
-      area_m2
-    end
+    MeasurementUnits.convert_area(area_m2, measurement_unit || project&.measurement_unit)
   end
 
   private

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,7 @@
 # app/models/project.rb
 
 class Project < ApplicationRecord
+  include MeasurementUnits
   has_paper_trail
   has_many :lots, dependent: :destroy
 
@@ -16,18 +17,8 @@ class Project < ApplicationRecord
 
   def price_for(area_in_m2)
     # Normalize area to the unit configured
-    case measurement_unit
-    when 'm2'
-      area_in_m2 * price_per_square_unit
-    when 'ft2'
-      # Convert m2 to ft2 then multiply
-      (area_in_m2 * 10.7639) * price_per_square_unit
-    when 'vara2'
-      # Convert m2 to vara2 (1 m2 = 1.431 vara2)
-      (area_in_m2 * 1.431) * price_per_square_unit
-    else
-      area_in_m2 * price_per_square_unit
-    end
+    normalized_area = MeasurementUnits.convert_area(area_in_m2, measurement_unit)
+    normalized_area * price_per_square_unit
   end
 
   private

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -4,17 +4,34 @@ class Project < ApplicationRecord
   has_paper_trail
   has_many :lots, dependent: :destroy
 
-  # Validaciones
+  MEASUREMENT_UNITS = %w[m2 ft2 vara2].freeze
+
   validates :name, :description, :address, presence: true
-  validates :price_per_square_vara, :interest_rate, numericality: { greater_than: 0 }
+  validates :price_per_square_unit, :interest_rate, numericality: { greater_than: 0 }
   validates :commission_rate, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }, presence: true
   validates :interest_rate, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }, presence: true
+  validates :measurement_unit, inclusion: { in: MEASUREMENT_UNITS }
 
   before_create :generate_guid
 
+  def price_for(area_in_m2)
+    # Normalize area to the unit configured
+    case measurement_unit
+    when 'm2'
+      area_in_m2 * price_per_square_unit
+    when 'ft2'
+      # Convert m2 to ft2 then multiply
+      (area_in_m2 * 10.7639) * price_per_square_unit
+    when 'vara2'
+      # Convert m2 to vara2 (1 m2 = 1.431 vara2)
+      (area_in_m2 * 1.431) * price_per_square_unit
+    else
+      area_in_m2 * price_per_square_unit
+    end
+  end
+
   private
 
-  # Método para calcular el precio total de todos los lotes
   def total_lot_value
     lots.sum(&:price)
   end

--- a/db/migrate/20250921000000_add_measurement_unit_to_projects_and_lots.rb
+++ b/db/migrate/20250921000000_add_measurement_unit_to_projects_and_lots.rb
@@ -1,4 +1,4 @@
-class AddMeasurementUnitToProjectsAndLots < ActiveRecord::Migration[7.0]
+class AddMeasurementUnitToProjectsAndLots < ActiveRecord::Migration[8.0]
   def change
     add_column :projects, :measurement_unit, :string, null: false, default: 'm2'
     add_column :lots, :measurement_unit, :string

--- a/db/migrate/20250921000000_add_measurement_unit_to_projects_and_lots.rb
+++ b/db/migrate/20250921000000_add_measurement_unit_to_projects_and_lots.rb
@@ -1,0 +1,18 @@
+class AddMeasurementUnitToProjectsAndLots < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :measurement_unit, :string, null: false, default: 'm2'
+    add_column :lots, :measurement_unit, :string
+
+    reversible do |dir|
+      dir.up do
+        rename_column :projects, :price_per_square_vara, :price_per_square_unit
+        execute <<~SQL
+          UPDATE lots SET measurement_unit = 'm2' WHERE measurement_unit IS NULL;
+        SQL
+      end
+      dir.down do
+        rename_column :projects, :price_per_square_unit, :price_per_square_vara
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_19_064114) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_21_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -76,6 +76,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_19_064114) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "address"
+    t.string "measurement_unit"
     t.index ["name"], name: "index_lots_on_name"
     t.index ["project_id"], name: "index_lots_on_project_id"
     t.index ["status"], name: "index_lots_on_status"
@@ -117,12 +118,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_19_064114) do
     t.string "project_type", default: "residential"
     t.string "address", null: false
     t.integer "lot_count", null: false
-    t.decimal "price_per_square_vara", precision: 10, scale: 2, null: false
+    t.decimal "price_per_square_unit", precision: 10, scale: 2, null: false
     t.decimal "interest_rate", precision: 5, scale: 2, null: false
     t.string "guid", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.decimal "commission_rate", precision: 5, scale: 2, default: "0.0", null: false
+    t.string "measurement_unit", default: "m2", null: false
     t.index ["name"], name: "index_projects_on_name"
   end
 

--- a/spec/integration/contracts_spec.rb
+++ b/spec/integration/contracts_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe 'Api::V1::ContractsController', type: :request do
       description: 'Descripción del proyecto',
       address: 'Dirección 1',
       lot_count: 5,
-      price_per_square_vara: 120.0,
+      price_per_square_unit: 120.0,
+      measurement_unit: 'm2',
       interest_rate: 5.5
     )
   end

--- a/spec/integration/lots_spec.rb
+++ b/spec/integration/lots_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe 'Api::V1::LotsController', type: :request do
       description: 'Descripción del proyecto',
       address: 'Dirección 1',
       lot_count: 5,
-      price_per_square_vara: 120.0,
+      price_per_square_unit: 120.0,
+      measurement_unit: 'm2',
       interest_rate: 5.5
     )
   end

--- a/spec/integration/payments_spec.rb
+++ b/spec/integration/payments_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe 'Api::V1::PaymentsController', type: :request do
       description: 'Descripción del proyecto',
       address: 'Dirección 1',
       lot_count: 5,
-      price_per_square_vara: 120.0,
+      price_per_square_unit: 120.0,
+      measurement_unit: 'm2',
       interest_rate: 5.5
     )
   end

--- a/spec/integration/projects_spec.rb
+++ b/spec/integration/projects_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe 'Api::V1::ProjectsController', type: :request do
       description: 'Descripción del proyecto',
       address: 'Dirección 1',
       lot_count: 5,
-      price_per_square_vara: 120.0,
+      price_per_square_unit: 120.0,
+      measurement_unit: 'm2',
       interest_rate: 5.5
     )
   end
@@ -57,11 +58,12 @@ RSpec.describe 'Api::V1::ProjectsController', type: :request do
           project_type: { type: :string },
           address: { type: :string },
           lot_count: { type: :integer },
-          price_per_square_vara: { type: :number },
+          price_per_square_unit: { type: :number },
+          measurement_unit: { type: :string },
           interest_rate: { type: :number },
           commission_rate: { type: :number }
         },
-        required: ['name', 'description', 'project_type', 'address', 'lot_count', 'price_per_square_vara']
+  required: ['name', 'description', 'project_type', 'address', 'lot_count', 'price_per_square_unit', 'measurement_unit']
       }
 
       response '201', 'Project created successfully' do
@@ -72,7 +74,8 @@ RSpec.describe 'Api::V1::ProjectsController', type: :request do
             project_type: 'Residential',
             address: '123 Main St',
             lot_count: 10,
-            price_per_square_vara: 150.0,
+            price_per_square_unit: 150.0,
+            measurement_unit: 'm2',
             interest_rate: 5.5,
             commission_rate: 2.0
           }
@@ -126,7 +129,8 @@ RSpec.describe 'Api::V1::ProjectsController', type: :request do
           project_type: { type: :string },
           address: { type: :string },
           lot_count: { type: :integer },
-          price_per_square_vara: { type: :number },
+          price_per_square_unit: { type: :number },
+          measurement_unit: { type: :string },
           interest_rate: { type: :number },
           commission_rate: { type: :number }
         }

--- a/spec/integration/users_spec.rb
+++ b/spec/integration/users_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe 'Api::V1::UsersController', type: :request do
       description: 'Descripción del proyecto',
       address: 'Dirección 1',
       lot_count: 5,
-      price_per_square_vara: 120.0,
+      price_per_square_unit: 120.0,
+      measurement_unit: 'm2',
       interest_rate: 5.5
     )
   end

--- a/spec/models/contract_spec.rb
+++ b/spec/models/contract_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Contract, type: :model do
 	let(:project) do
 		Project.new(
 			name: 'TestProject', description: 'Desc', address: 'Addr',
-			lot_count: 1, price_per_square_vara: 100, interest_rate: 5, guid: 'guid'
+			lot_count: 1, price_per_square_unit: 100, measurement_unit: 'm2', interest_rate: 5, guid: 'guid'
 		)
 	end
 

--- a/spec/models/lot_spec.rb
+++ b/spec/models/lot_spec.rb
@@ -1,22 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe Lot, type: :model do
-  let(:project) { Project.new(name: 'P', description: 'D', address: 'A', price_per_square_vara: 100.0, interest_rate: 1.0, commission_rate: 5.0) }
+  let(:project) { Project.new(name: 'P', description: 'D', address: 'A', price_per_square_unit: 100.0, measurement_unit: 'm2', interest_rate: 1.0, commission_rate: 5.0) }
   subject { described_class.new(name: 'Lote A', length: 10.0, width: 5.0, project: project) }
 
   it 'is valid with required attributes' do
     expect(subject).to be_valid
   end
 
-  it 'calculates area in m2 and other units' do
+  it 'calculates area in m2 and converts based on project measurement_unit' do
+    # default project unit m2
     expect(subject.area_m2).to eq(50.0)
-    expect(subject.area_square_feet).to be_within(0.001).of(50.0 * 10.7639)
-    expect(subject.area_square_vara).to be_within(0.001).of(50.0 * 1.431)
+    expect(subject.area_in_project_unit).to be_within(0.0001).of(50.0)
+
+    project.measurement_unit = 'ft2'
+    expect(subject.area_in_project_unit).to be_within(0.0001).of(50.0 * 10.7639)
+
+    project.measurement_unit = 'vara2'
+    expect(subject.area_in_project_unit).to be_within(0.0001).of(50.0 * 1.431)
   end
 
-  it 'sets the price before save using project price_per_square_vara' do
+  it 'sets the price before save using project price_per_square_unit' do
     # Avoid persisting by calling the callback directly
-    allow(project).to receive(:price_per_square_vara).and_return(100.0)
+    allow(project).to receive(:price_for).and_call_original
     subject.send(:calculate_price)
     expect(subject.price).to be_present
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Project, type: :model do
-  subject { described_class.new(name: 'P', description: 'Desc', address: 'Addr', price_per_square_vara: 10.0, interest_rate: 1.0, commission_rate: 5.0) }
+  subject { described_class.new(name: 'P', description: 'Desc', address: 'Addr', price_per_square_unit: 10.0, measurement_unit: 'm2', interest_rate: 1.0, commission_rate: 5.0) }
 
   it 'is valid with required attributes' do
     expect(subject).to be_valid


### PR DESCRIPTION
## Schema & Fields
- **Rename** `Project.price_per_square_vara` → `Project.price_per_square_unit`  
- **Add** `measurement_unit` to `projects` (default: `m2`; allowed: `m2`, `ft2`, `vara2`)  
- **Add** `measurement_unit` to `lots` (inherits from project if blank)  

## Pricing & Logic
- **Introduce** normalized pricing via `Project#price_for(area_in_m2)`  
- **Refactor** lot price callback to use `project.price_for`  
- **Replace** old area helpers with `Lot#area_in_project_unit`  

## API & Serialization
- **Extend** Lots API responses to include `measurement_unit`  
- **Update** strong params in `ProjectsController` and `LotsController`  
- **Adjust** JSON serialization for projects/lots to reflect new field names  

## Data Migration
- **Add** reversible migration for unit + price rename  
- **Backfill** lot `measurement_unit` to `m2`  

## Tests
- **Update** all specs (models + integration) to new naming  
- **Fix** failing user integration specs referencing old price field  
- **Remove** references to deprecated `area_square_feet` / `area_square_vara` in specs  